### PR TITLE
Replace Door43 contact info with WA helpdesk

### DIFF
--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -197,7 +197,7 @@ function showWarningModal(modal_body){
             modal_body +
             '      </div>'+
             '      <div class="modal-footer">'+
-            '        <a href="mailto:help@door43.org'+
+            '        <a href="mailto:helpdesk@wycliffeassociates.org'+
             '?subject='+encodeURIComponent('Build Warning: '+myOwner+'/'+myRepoName)+
             '&body='+encodeURIComponent("Type your question here\n\nSee the failure at "+window.location.href+"\n\n")+
             '" class="btn btn-secondary raised">Ask the Help Desk</a>'+

--- a/pages/en/contact.md
+++ b/pages/en/contact.md
@@ -4,69 +4,10 @@ title: Contact
 permalink: /en/contact/index.html
 ---
 
-## Slack
+## Contact form
 
-The fastest way to get answers is to ask the [#helpdesk](https://team43.slack.com/messages/helpdesk/) channel in our Team43 Slack Group.  Use the form below to join our Slack team if you are not a member.
-
-<script type="text/javascript">
-  function disable_page() {
-    var cover = document.getElementById('gray_cover');
-    cover.style.display = 'inline-block';
-  }
-
-  function enable_page() {
-    var cover = document.getElementById('gray_cover');
-    cover.style.display = 'none';
-  }
-
-  function signUp(f) {
-
-    var url = 'https://api.door43.org/slack/invite';
-    disable_page();
-
-    $.ajax({
-        url: url,
-        type: 'GET',
-        data: $(f).serialize(),
-        dataType: 'jsonp',
-        success: function (data, status) {
-            if (data['result'] === 'success') {
-                alert('An invitation has been sent to your e-mail address');
-            }
-            else {
-                alert('A problem was encountered: ' + data['message'] + '.');
-            }
-            enable_page();
-        },
-        error: function (jqXHR, textStatus, errorThrown) {
-            console.log('Error: ' + textStatus + '\n' +  errorThrown);
-            alert(textStatus);
-            enable_page();
-        }
-    });
-
-    return false;
-  }
-</script>
-<div id="gray_cover" style="position:fixed;top:0;left:0;overflow:hidden;display:none;width:100%;height:100%;background-color:#000000;opacity:0.5;MozOpacity:0.5;z-index:150;filter:alpha(opacity=50);cursor: wait;"></div>
-<form onsubmit="return signUp(this)" action="" method="POST">
-    <fieldset id="slack-fields">
-        <legend>Team43 Slack Sign Up Form</legend>
-        <p>By using this service you agree to our <a href="/en/slack-terms-of-service/">Slack Terms of Service</a>.</p>
-        <label for="first_name"><span>First Name: </span><input type="text" name="first_name" id="first_name"></label>
-        <label for="last_name"><span>Last Name: </span><input type="text" name="last_name" id="last-name"></label>
-        <label for="email"><span>E-Mail: </span><input type="email" name="email" id="email"></label>
-        <input type="hidden" name="token" value="IByqnIF8ql+jXkKvvTQZCvc32RH2K2jKxRyy2EeLE7rmjui3VHBAQTelUi8vz3Dmw5c9zxV7YL9UupucBADk1RJn+hgg2P+S">
-        <button type="submit">Sign Up</button>
-    </fieldset>
-</form>
+The best way to get help with _Bible in Every Language_ is by our [contact form](https://bibleineverylanguage.org/contact/).
 
 ## E-Mail
 
-If you prefer, you may also e-mail our help desk at [help@door43.org][help-mail].
-
-## Knowledgebase
-
-You may also find help articles on the [Door43 Knowledgebase](http://help.door43.org/en/knowledgebase).
-
-[help-mail]: mailto:help@door43.org "help@door43.org"
+If you prefer, you may also e-mail our help desk at <helpdesk@wycliffeassociates.org>.

--- a/test/spec/SpecWarningModal.js
+++ b/test/spec/SpecWarningModal.js
@@ -9,7 +9,7 @@ describe('Test Warning Modal', function () {
         var expectedLength = 2;
         expect($('#warning-modal .modal-body li').length).toEqual(expectedLength);
 
-        var expectedText = 'mailto:help@door43.org?subject='+encodeURIComponent('Build Warning: '+myOwner+'/'+myRepoName);
+        var expectedText = 'mailto:helpdesk@wycliffeassociates.org?subject='+encodeURIComponent('Build Warning: '+myOwner+'/'+myRepoName);
         const $help_button = $('#warning-modal .btn-secondary:first');
         expect($help_button.attr('href')).toContain(expectedText);
     });


### PR DESCRIPTION
- Update email addresses.
- Update `/contact` page to remove d43 Slack links.